### PR TITLE
READMEのリンクの前後にスペースを挿入

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Claude MCPから不動産情報ライブラリAPIを統合的に呼び出すた�
 
    **【Pythonをインストール】**
    * Pythonをインストールしてください。（バージョンは、3.10以上をインストールしてください。）  
-   Pythonの公式ダウンロードページ[https://www.python.org/downloads/windows/]から、利用OSに合わせて3.10以上のインストーラーをダウンロードして、インストーラーを起動してください。
+   Pythonの公式ダウンロードページ [https://www.python.org/downloads/windows/] から、利用OSに合わせて3.10以上のインストーラーをダウンロードして、インストーラーを起動してください。
    * インストーラーの指示に従って、インストールを行ってください。  
       画面下部の「Add Python 3.x to PATH」のチェックボックスにチェックを入れてから、 Install Now を選択してください。  
       ※「Add Python 3.x to PATH」のチェックボックスにチェックを忘れてインストールした場合は、環境変数にPython.exeの場所を追加してください。
@@ -67,12 +67,12 @@ Claude MCPから不動産情報ライブラリAPIを統合的に呼び出すた�
       quit() と入力しEnterを押して、Pythonを終了してください。
 
 2. **Claude Desktopをダウンロード・インストール**
-   * Claudeの公式ダウンロードページ[https://claude.com/download]にアクセスし、インストーラーをダウンロードしてください。
+   * Claudeの公式ダウンロードページ [https://claude.com/download] にアクセスし、インストーラーをダウンロードしてください。
    * ダウンロードしたファイルを実行するとインストールが開始されます。  
       画面の案内に従って「始める」をクリックし、アカウント認証を行うことでインストールが完了します。
 
 3. **不動産情報ライブラリのAPI利用申請**
-   • 不動産情報ライブラリの公式ページ[https://www.reinfolib.mlit.go.jp/api/request/]にアクセスし、API利用申請をしてください。   
+   • 不動産情報ライブラリの公式ページ [https://www.reinfolib.mlit.go.jp/api/request/] にアクセスし、API利用申請をしてください。   
 
 4. **ソースコードをcloneする**
    * cloneするためのディレクトリを作成します。（例：mlit-geospatial-mcp）


### PR DESCRIPTION
リンクのレンダリングがGitHub上での表示の際に壊れていて、リンクに後続する自然言語部分までURLとして判定されていた問題を修正しました。