### PR TITLE
fix: クロスプラットフォーム対応とHTTPリクエストの安全性向上

### DIFF
--- a/src/request_processor/common/change_address.py
+++ b/src/request_processor/common/change_address.py
@@ -4,6 +4,9 @@ import requests
 
 from utils.const import LIBRARY_API_KEY, LIBRARY_API_URL
 
+# 接続5秒・読み取り30秒。MCPサーバー全体のハングを防ぐ。
+DEFAULT_TIMEOUT = (5, 30)
+
 PREFECTURE_CODES = {
     "01": "北海道",
     "02": "青森県",
@@ -95,6 +98,6 @@ def get_libraryapi(pref_cd):
             "User-Agent": "REINS-Client",
             "Ocp-Apim-Subscription-Key": LIBRARY_API_KEY,
         },
-        verify=False,
+        timeout=DEFAULT_TIMEOUT,
     )
     return response.json()

--- a/src/request_processor/common/point_filter.py
+++ b/src/request_processor/common/point_filter.py
@@ -35,16 +35,15 @@ def filter_distance(
         geom_type = geom.get("type")
         coords = geom.get("coordinates")
 
-        if geom_type in ["Point", "LineString"]:
-            if geom_type == "Point":
-                target_lon, target_lat = coords
-                target_geom = f"POINT({target_lon} {target_lat})"
-            # ライン
-            elif geom_type == "LineString":
-                coord_str = ", ".join(
-                    f"{target_lon} {target_lat}" for target_lon, target_lat in coords
-                )
-                target_geom = f"LINESTRING({coord_str})"
+        if geom_type == "Point":
+            target_lon, target_lat = coords
+            target_geom = f"POINT({target_lon} {target_lat})"
+        elif geom_type == "LineString":
+            coord_str = ", ".join(f"{lon} {lat}" for lon, lat in coords)
+            target_geom = f"LINESTRING({coord_str})"
+        else:
+            # Point / LineString 以外（Polygon等）は距離フィルタ非対応のためスキップ
+            continue
 
         # 距離チェック
         result = get_distance(search_geom, target_geom)

--- a/src/request_processor/common/requester.py
+++ b/src/request_processor/common/requester.py
@@ -6,6 +6,9 @@ from utils.logger_config import setup_logger
 
 logger = setup_logger(__name__)
 
+# 接続5秒・読み取り30秒。MCPサーバー全体のハングを防ぐ。
+DEFAULT_TIMEOUT = (5, 30)
+
 
 def get(
     url: str, params: dict = None, response_type: str = "json", headers: dict = None
@@ -13,7 +16,9 @@ def get(
     headers = headers or {"Accept": "*/*"}
 
     try:
-        response = requests.get(url, headers=headers, params=params, verify=False)
+        response = requests.get(
+            url, headers=headers, params=params, timeout=DEFAULT_TIMEOUT
+        )
         response.raise_for_status()
 
         if response_type in ("json", "geojson"):

--- a/src/request_processor/service/geospatial_service.py
+++ b/src/request_processor/service/geospatial_service.py
@@ -87,7 +87,9 @@ class GeospatialService:
                 ),
             }
 
-        base_output_folder = "C:/output"
+        # output_dir 未指定時のデフォルト保存先。
+        # クロスプラットフォーム対応のため、ユーザーホーム配下を使用する。
+        base_output_folder = Path.home() / "Documents" / "mlit-geospatial-mcp"
         file_paths = []
 
         now_folder = datetime.now().strftime("%Y%m%d%H%M")
@@ -172,7 +174,7 @@ class GeospatialService:
                     ):
                         output_folder = Path(output_dir.strip()) / now_folder
                     else:
-                        output_folder = Path(base_output_folder) / now_folder
+                        output_folder = base_output_folder / now_folder
                     output_folder.mkdir(parents=True, exist_ok=True)
 
                     for idx, payload_to_write, file_name in save_targets:

--- a/src/utils/geocoder.py
+++ b/src/utils/geocoder.py
@@ -2,13 +2,16 @@ import requests
 
 from utils.const import RGEOCODER_URL
 
+# 接続5秒・読み取り30秒。MCPサーバー全体のハングを防ぐ。
+DEFAULT_TIMEOUT = (5, 30)
+
 
 # 住所から緯度経度(国土地理院のジオコーダ)
 def get_latlon(full_addr):
     response = requests.get(
         f"{RGEOCODER_URL}?q={full_addr}",
         headers={"User-Agent": "REINS-Client"},
-        verify=False,
+        timeout=DEFAULT_TIMEOUT,
     )
 
     result = response.json()

--- a/src/utils/reverse_geocoder.py
+++ b/src/utils/reverse_geocoder.py
@@ -2,13 +2,16 @@ import requests
 
 from utils.const import RE_RGEOCODER_URL
 
+# 接続5秒・読み取り30秒。MCPサーバー全体のハングを防ぐ。
+DEFAULT_TIMEOUT = (5, 30)
+
 
 # 緯度経度から都道府県CD検索(国土地理院による逆ジオコーダ)
 def get_citycd(lat, lon):
     response = requests.get(
         f"{RE_RGEOCODER_URL}?lat={lat}&lon={lon}",
         headers={"User-Agent": "REINS-Client"},
-        verify=False,
+        timeout=DEFAULT_TIMEOUT,
     )
     if response.status_code == 200:
         result = response.json()


### PR DESCRIPTION
## 概要

issue #15 の **Critical 1〜4** に対応するバグ修正PRです。
いずれも独立したバグ修正で、機能追加や仕様変更は含みません。

> 既存PR #10 / #12 / #13 と変更ファイル・変更内容に重複はありません。

## 変更内容

### 1. デフォルト保存先をクロスプラットフォーム対応に
`src/request_processor/service/geospatial_service.py`

\`\`\`diff
- base_output_folder = \"C:/output\"
+ base_output_folder = Path.home() / \"Documents\" / \"mlit-geospatial-mcp\"
\`\`\`

READMEに記載のあるmacOSで \`output_dir\` 未指定だと \`C:/output\` という不正パスが作られていた挙動を修正。Windowsでも \`C:\\Users\\<user>\\Documents\\mlit-geospatial-mcp\` に保存されるようになります。

### 2. \`verify=False\` を削除し、\`timeout\` を付与
4ファイル（\`requester.py\` / \`change_address.py\` / \`reverse_geocoder.py\` / \`geocoder.py\`）。

- いずれの呼び出し先（GSI / reinfolib）も標準的な公的SSL証明書を持っており、\`verify=True\`（デフォルト）で問題なく動作することを確認済み
- \`timeout=(5, 30)\` を共通定数として付与し、ネットワーク異常時のMCPサーバーハングを防止

### 3. \`filter_distance\` の \`UnboundLocalError\` ガード
\`src/request_processor/common/point_filter.py\`

Point / LineString 以外のジオメトリ型に対して \`target_geom\` が未定義のまま参照されていた箇所を、\`continue\` でスキップするよう修正。LineStringの内包表記内で外側変数を上書きしていた点も併せて整理しました。

## 動作確認

- \`python3 -m py_compile\` で構文チェック済み
- \`requests.get\` にtimeoutを付けた4箇所はパラメータ追加のみのため、既存の挙動への影響は無し
- GSI（mreversegeocoder.gsi.go.jp / msearch.gsi.go.jp）が \`verify=True\` で200応答することをcurlで確認済み

## 関連
- closes #15 の Critical 1〜4 部分
- Critical 5（複数座標対応の未完了）と Improvement 群は本PRのスコープ外。issue上での議論を経て、別途対応可否をご判断いただきたく存じます。

ご確認のほどよろしくお願いいたします 🙏